### PR TITLE
Added suggested labels, total histograms

### DIFF
--- a/services/modelling/src/Ss2Main.cpp
+++ b/services/modelling/src/Ss2Main.cpp
@@ -171,6 +171,7 @@ public:
 		else TStateAggScaleSelector::SelectScales(*model, allPartitions, nScales, selectedPartitions);
 		// Calculate various statistics about the model.
 		model->CalcHistograms();
+		model->CalcLabels();
 		// ToDo: state labels, decision trees etc. should also be calculated here.
 		// Export the model to json.
 		req.outJson->AddToObj("model",  model->SaveToJson());


### PR DESCRIPTION
- A suggested label is provided for each state.
- Total histograms (for the whole dataset as opposed to for an individual state) are now provided.
- The JSON object for each state now includes the number of that state (within its scale) and the list of numbers of its children (on the next lower scale).