### PR TITLE
Support for conversion errors and default attribute weights

### DIFF
--- a/services/modelling/src/Ss2Main.cpp
+++ b/services/modelling/src/Ss2Main.cpp
@@ -162,6 +162,7 @@ public:
 		if (! dataset->ReadDataFromJsonDataSourceSpec(req.inJson->GetObjKey("dataSource"), req.errList)) { req.status = "error"; return false; }
 		if (! dataset->ApplyOps(req.errList)) { req.status = "error"; return false; }
 		if (dataset->nRows < config->numInitialStates) { req.status = "error"; req.errList.Add(TStr::Fmt("Not enough data (%d initial states were requested, %d rows are available).", config->numInitialStates, dataset->nRows)); return false; }
+		dataset->CalcDefaultDistWeights();
 		// Build the model.
 		PModel model = new TModel(dataset);
 		TKMeansRunner::BuildInitialStates(*model);
@@ -191,7 +192,7 @@ public:
 int TestBuildModelRequest()
 {
 	TJsonRequest req;
-	if (req.InitInJsonFromFile("call.json")) TBuildModelFun::ProcessRequest(req);
+	if (req.InitInJsonFromFile("call-braila.json")) TBuildModelFun::ProcessRequest(req);
 	TStr resultStr = req.FinalizeResponse();
 	FILE *f = fopen("callResult.json", "wt");
 	fprintf(f, "%s\n", resultStr.CStr());


### PR DESCRIPTION
- The service now keeps reading data despite conversion errors, but ignores rows where errors occurred.  This behaviour can be disabled by setting config.ignoreConversionErrors = true.

- The default value of distWeight is no longer 1, but 1 / (variance of the attribute).  For the purpose of calculating the variance, the highest and lowest few values are ignored; this can be controlled via config.distWeightOutliers (default: 0.05, meaning that the highest and lowest 2.5% of the values are ignored).