### PR TITLE
Classification support

### DIFF
--- a/services/modelling/src/sampleCall/testCall.py
+++ b/services/modelling/src/sampleCall/testCall.py
@@ -53,4 +53,65 @@ def BuildModel(hostAndPort, fnInJson, fnInData, sendDataAsInternal, fnOutJson):
     json.dump(jsonOut, f, indent = 4)  # prettyprint the JSON response object
     f.close()
 
-BuildModel("capybara.ijs.si:8096", "call.json", "d:\\users\\janez\\data\\StreamStory\\B100_hour_SS_input.csv", True, "callResult.json")
+BuildModel("capybara.ijs.si:8096", "call.json", "d:\\users\\janez\\data\\StreamStory\\B100_hour_SS_input.csv", True, "callResult-buildModel.json")
+
+def ClassifySamples(hostAndPort, fnInModelJson, fnInData, sendDataAsInternal, fnOutJson):
+    # We assume that fnInModelJson contains the entire JSON response
+    # returned by the /buildModel function.  That is, in addition to the
+    # model itself it also contains "status" and possibly an "errors" array.
+    # We must send only the model itself to the /classifySamples function.
+    f = open(fnInModelJson, "rt")
+    jsonModel = json.load(f)
+    f.close()
+    #
+    jsonIn = {
+        "dataSource": { },
+        "model": jsonModel["model"]
+    }
+    assert fnInData
+    if sendDataAsInternal:
+        # Read the contents of 'fnInData' and provided them as
+        # the 'data' member of the request object.
+        jsonIn["dataSource"]["type"] = "internal"
+        if fnInData.lower().endswith(".csv"):
+            f = open(fnInData, "rt")
+            inData = f.read()
+            f.close()
+            jsonIn["dataSource"]["data"] = inData
+            jsonIn["dataSource"]["format"] = "csv"
+        elif fnInData.lower().endswith(".json"):
+            f = open(fnInData, "rt")
+            inData = json.load(f)
+            f.close()
+            jsonIn["dataSource"]["data"] = inData
+            jsonIn["dataSource"]["format"] = "json"
+        else: assert False    
+    else:
+        # Provide the filename of 'fnInData' as a string in the
+        # request object and let the server read the file directly.
+        if fnInData.lower().endswith(".csv"): jsonIn["dataSource"]["format"] = "csv"
+        elif fnInData.lower().endswith(".csv"): jsonIn["dataSource"]["format"] = "json"
+        else: assert False
+        jsonIn["dataSource"]["type"] = "file"
+        jsonIn["dataSource"]["fileName"] = fnInData
+    # Prepare a HTTP request.    
+    reqData = json.dumps(jsonIn).encode("ascii")
+    print("Sending request (%d bytes)..." % len(reqData))
+    req = urllib.request.Request("http://" + hostAndPort + "/classifySamples",
+        data = reqData,
+        headers = {"Content-Type": "application/json"},
+        method = "POST")
+    # Read the response.
+    response = urllib.request.urlopen(req)
+    print("Response: %s" % response.getcode())
+    print("- Info: %s" % response.info())
+    respBody = response.read()
+    print("- Body: %s bytes long" % len(respBody))
+    # Save the response to a file.
+    jsonOut = json.loads(respBody)
+    f = open(fnOutJson, "wt")
+    #f.write(respBody)
+    json.dump(jsonOut, f, indent = 4)  # prettyprint the JSON response object
+    f.close()
+
+ClassifySamples("capybara.ijs.si:8096", "callResult-buildModel.json", "d:\\users\\janez\\data\\StreamStory\\B100_hour_SS_input.csv", True, "callResult-classifySamples.json")


### PR DESCRIPTION
The service now supports the /classifySamples function, which takes as input a model and a set of datapoints, and outputs, for each of these datapoints, the number of the initial state whose centroid was the closest to that datapoint.

The JSON represetation of the model returned by the /buildModel function now contains additional structures required by /classifySamples.  Thus /classifySamples will not work with models produced by earlier versions of the service.

Each state object in the JSON output of /buildModel now contains a boolean field named "sameAsParent" which indicates whether the state is identical to its parent.  If yes, the state will not include the following fields: histograms, centroid, decisionTree, suggestedLabel.  The caller should copy them from the parent state instead.  This significantly reduces the size of the JSON representation of the model.

A new version of sampleCall/testCall.py is provided which now also shows how to use the new /classifySamples function.